### PR TITLE
Install generator

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,0 +1,1 @@
+# ruby encoding: utf-8

--- a/lib/generators/swattr/install/install_generator.rb
+++ b/lib/generators/swattr/install/install_generator.rb
@@ -25,7 +25,21 @@ module Swattr
       def add_swattr_seed
         say "Seeding local seeds.rb..."
 
-        append_file "db/seeds.rb", "Swattr::Engine.load_seed\n"
+        unless File.exists? File.join(destination_root, "db", "seeds.rb")
+          say "Creating db/seeds.rb first..."
+
+          create_file "db/seeds.rb"
+
+          say "Ok, NOW seeding local seeds.rb..."
+        end
+
+        append_file "db/seeds.rb", verbose: true do
+          <<-SEED
+# Swattr seed data
+Swattr::Engine.load_seed
+
+          SEED
+        end
       end
 
       def install_migrations

--- a/lib/generators/swattr/install/install_generator.rb
+++ b/lib/generators/swattr/install/install_generator.rb
@@ -7,7 +7,7 @@ module Swattr
       source_root File.expand_path("../templates", __FILE__)
 
       class_option :migrate, type: :boolean, default: true
-      class_option :seed, type: :boolean, default: true
+      class_option :seed, type: :boolean, default: false
 
       def add_env_file
         say "Copying example .env file..."
@@ -60,17 +60,17 @@ Swattr::Engine.load_seed
 
           silence_warnings { rake "db:migrate" }
         else
-          say "  Skipping migrations. Be sure to run `rake db:migrate` yourself"
+          say "Skipping migrations. Be sure to run `rake db:migrate` yourself."
         end
       end
 
       def seed_database
-        if options[:seed]
+        if options[:migrate] && options[:seed]
           say "Inseminating..."
 
           quietly { rake "rake db:seed" }
         else
-          say "  Skipping seed. Run `rake db:seed` later"
+          say "Skipping seed data. Run `rake db:seed` yourself."
         end
       end
 
@@ -79,20 +79,22 @@ Swattr::Engine.load_seed
 
         insert_into_file File.join("config", "routes.rb"),
           after: "Rails.application.routes.draw do\n" do
-            %Q{
+            <<-ROUTES
   # This line mounts Swattr's routes at the root of your application. If you
   # would like to change where this engine is mounted, simply change the :at
   # option to reflect your needs.
   mount Swattr::Engine, at: "/"
 
-}
+            ROUTES
         end
 
-        say "  Your application's config/routes.rb has been updated."
+        say "Your application's config/routes.rb has been updated."
       end
 
       def complete
-        say "Done, sir! Done! Swattr has been installed!"
+        say "*" * 50
+        say "  Done, sir! Done! Swattr has been installed!"
+        say "*" * 50
       end
     end
   end

--- a/lib/generators/swattr/install/install_generator.rb
+++ b/lib/generators/swattr/install/install_generator.rb
@@ -7,7 +7,7 @@ module Swattr
       source_root File.expand_path("../templates", __FILE__)
 
       class_option :migrate, type: :boolean, default: true
-      class_option :seed, type: :boolean, default: false
+      class_option :seed, type: :boolean, default: true
 
       def add_env_file
         say "Copying example .env file..."
@@ -51,11 +51,12 @@ module Swattr
       end
 
       def seed_database
-        if options[:seed] ||
-          agree("Would you like to seed the database? (y/N)", false)
+        if options[:seed]
           say "Inseminating..."
 
           quietly { rake "rake db:seed" }
+        else
+          say "  Skipping seed. Run `rake db:seed` later"
         end
       end
 

--- a/lib/generators/swattr/install/install_generator.rb
+++ b/lib/generators/swattr/install/install_generator.rb
@@ -1,0 +1,84 @@
+require "rails/generators"
+require "highline/import"
+
+module Swattr
+  module Generators
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path("../templates", __FILE__)
+
+      class_option :migrate, type: :boolean, default: true
+      class_option :seed, type: :boolean, default: false
+
+      def add_env_file
+        say "Copying example .env file..."
+
+        copy_file(".env.example", ".env.example")
+      end
+
+      def add_swattr_initializer
+        say "Copying Swattr initializer..."
+
+        copy_file("config/initializers/swattr.rb",
+                  "config/initializers/swattr.rb")
+      end
+
+      def add_swattr_seed
+        say "Seeding local seeds.rb..."
+
+        append_file "db/seeds.rb", "Swattr::Engine.load_seed\n"
+      end
+
+      def install_migrations
+        say "Installing migrations..."
+
+        silence_warnings { rake "railties:install:migrations" }
+      end
+
+      def create_database
+        say "Creating database..."
+
+        silence_warnings { rake "db:create" }
+      end
+
+      def run_migrations
+        if options[:migrate]
+          say "Running migrations..."
+
+          silence_warnings { rake "db:migrate" }
+        else
+          say "  Skipping migrations. Be sure to run `rake db:migrate` yourself"
+        end
+      end
+
+      def seed_database
+        if options[:seed] ||
+          agree("Would you like to seed the database? (y/N)", false)
+          say "Inseminating..."
+
+          quietly { rake "rake db:seed" }
+        end
+      end
+
+      def insert_routes
+        say "Adding Swattr routes..."
+
+        insert_into_file File.join("config", "routes.rb"),
+          after: "Rails.application.routes.draw do\n" do
+            %Q{
+  # This line mounts Swattr's routes at the root of your application. If you
+  # would like to change where this engine is mounted, simply change the :at
+  # option to reflect your needs.
+  mount Swattr::Engine, at: "/"
+
+}
+        end
+
+        say "  Your application's config/routes.rb has been updated."
+      end
+
+      def complete
+        say "Done, sir! Done! Swattr has been installed!"
+      end
+    end
+  end
+end

--- a/lib/generators/swattr/install/templates/.env.example
+++ b/lib/generators/swattr/install/templates/.env.example
@@ -1,0 +1,4 @@
+S3_BUCKET_NAME=bucket_name
+S3_ACCESS_KEY=access_key
+S3_SECRET_ACCESS_KEY=secret_access_key
+S3_REGION=bucket_region

--- a/lib/generators/swattr/install/templates/config/initializers/swattr.rb
+++ b/lib/generators/swattr/install/templates/config/initializers/swattr.rb
@@ -1,0 +1,9 @@
+Swattr.configure do |config|
+  # Results per page.
+  # Default is 24.
+  # config.per_page = 24
+
+  # Application.
+  # Default is "swattr".
+  # config.application = "swattr"
+end

--- a/lib/swattr.rb
+++ b/lib/swattr.rb
@@ -1,4 +1,16 @@
 require "swattr/engine"
+require "swattr/configuration"
 
 module Swattr
+  class << self
+    attr_accessor :configuration
+
+    def configure
+      yield configuration
+    end
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+  end
 end

--- a/lib/swattr/configuration.rb
+++ b/lib/swattr/configuration.rb
@@ -1,0 +1,27 @@
+module Swattr
+  class Configuration
+    DEFAULT_VALUE = nil
+
+    attr_accessor :application,
+                  :per_page
+
+    def initialize
+      @application = "swattr"
+      @per_page    = 24
+    end
+
+    def method_missing(method_name, *args)
+      super(method_name, *args)
+    rescue NoMethodError
+      method = method_name.to_s
+
+      if method[-1] == "?"
+        column = method.sub("?", "")
+
+        self.send(column.to_sym, *args) != DEFAULT_VALUE
+      else
+        DEFAULT_VALUE
+      end
+    end
+  end
+end

--- a/lib/tasks/swattr_tasks.rake
+++ b/lib/tasks/swattr_tasks.rake
@@ -1,4 +1,5 @@
-# desc "Explaining what the task does"
 # task :swattr do
-#   # Task goes here
+#   desc "Explaining what the task does"
+#   task :something do
+#   end
 # end

--- a/lib/tasks/swattr_tasks.rake
+++ b/lib/tasks/swattr_tasks.rake
@@ -1,4 +1,4 @@
-# task :swattr do
+# namespace :swattr do
 #   desc "Explaining what the task does"
 #   task :something do
 #   end

--- a/swattr.gemspec
+++ b/swattr.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency "rails", "~> 4.2.4"
+  s.add_dependency "highline", "~> 1.7.7"
 
   s.add_development_dependency "rspec-rails", "~> 3.3.3"
   s.add_development_dependency "factory_girl_rails", "~> 4.5.0"


### PR DESCRIPTION
- Copy `.env.example` with S3 env vars (for future use) 
- Copy `config/initializers/swattr.rb`
- Add Swattr seed to application `db/seeds.rb` file
- Copy migrations
- Create database
- Run migrations
- Seed database
- Insert Swattr routes to `config/routes.rb`

Migrations can be turned off by running either `rails g swattr:install --no-migrate` or `rails g swattr:install --migrate=false`

Seed data is turned off by default. Seed data can be turned on by running either `rails g swattr:install --seed` or `rails g swattr:install --seed=true`

Also adds the beginning of application configurations with `Swattr::Configuration` to be accessed using `Swattr.configuration.xyz`.
