### PR TITLE
Rename slug and email when marked as deleted

### DIFF
--- a/app/models/swattr/project.rb
+++ b/app/models/swattr/project.rb
@@ -2,6 +2,8 @@ module Swattr
   class Project < ActiveRecord::Base
     acts_as_paranoid
 
+    after_destroy :slug_reset
+
     # Associations
     belongs_to :author, class_name: Swattr::User
     belongs_to :owner, class_name: Swattr::User
@@ -14,5 +16,10 @@ module Swattr
 
     # Default scope
     # default_scope { order(name: :asc, slug: :asc) }
+
+    # Callbacks
+    def slug_reset
+      update(slug: "#{Time.current.to_i}_#{slug}")
+    end
   end
 end

--- a/app/models/swattr/user.rb
+++ b/app/models/swattr/user.rb
@@ -2,6 +2,8 @@ module Swattr
   class User < ActiveRecord::Base
     acts_as_paranoid
 
+    after_destroy :email_reset
+
     devise :database_authenticatable, :registerable, :recoverable, :lockable,
            :rememberable, :trackable, :validatable, :confirmable, :timeoutable,
            :invitable
@@ -18,5 +20,10 @@ module Swattr
 
     # Default scope
     # default_scope { order(name: :asc, email: :asc) }
+
+    # Callbacks
+    def email_reset
+      update(email: "#{Time.current.to_i}_#{email}")
+    end
   end
 end


### PR DESCRIPTION
Rename project slug and user email when they are marked as deleted by paranoia.
