### PR TITLE
Use project slug for routes

### DIFF
--- a/app/controllers/swattr/issues_controller.rb
+++ b/app/controllers/swattr/issues_controller.rb
@@ -56,7 +56,7 @@ module Swattr
     end
 
     def set_project
-      @project = Swattr::Project.find(@issue.project_id)
+      @project = Swattr::Project.find_by(slug: params[:project_id])
     end
 
     def issue_params

--- a/app/controllers/swattr/projects_controller.rb
+++ b/app/controllers/swattr/projects_controller.rb
@@ -51,7 +51,7 @@ module Swattr
     end
 
     def set_project
-      @project = Swattr::Project.find(params[:id])
+      @project = Swattr::Project.find_by(slug: params[:id])
     end
 
     def project_params

--- a/app/models/swattr/project.rb
+++ b/app/models/swattr/project.rb
@@ -21,5 +21,10 @@ module Swattr
     def slug_reset
       update(slug: "#{Time.current.to_i}_#{slug}")
     end
+
+    # Paramater
+    def to_param
+      slug
+    end
   end
 end


### PR DESCRIPTION
Use the project slug for routes instead of project ID. Route become `/projects/SLUG`, `/projects/SLUG/issues`, `/projects/SLUG/issues/1234`. `/projects/1234` will now throw an error unless `1234` is actually the slug for the project.
